### PR TITLE
Fixing Spotify Music Control

### DIFF
--- a/HyprRun/RunViewModel.swift
+++ b/HyprRun/RunViewModel.swift
@@ -20,7 +20,6 @@ class RunViewModel: NSObject {
   var run: Run?
   var seconds = 0
   var timer: Timer?
-	//var timer = Timer.publish(every: 1, on: .current, in: .common).autoconnect()
 
   var distance = Measurement(value: 0, unit: UnitLength.meters)
   var locationList: [CLLocation] = []

--- a/HyprRun/RunViewModel.swift
+++ b/HyprRun/RunViewModel.swift
@@ -20,6 +20,8 @@ class RunViewModel: NSObject {
   var run: Run?
   var seconds = 0
   var timer: Timer?
+	//var timer = Timer.publish(every: 1, on: .current, in: .common).autoconnect()
+
   var distance = Measurement(value: 0, unit: UnitLength.meters)
   var locationList: [CLLocation] = []
   
@@ -95,6 +97,7 @@ class UIRunViewModel: RunViewModel, ObservableObject {
     timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
       self.eachSecond()
     }
+		self.eachSecond()
     self.currentState = .running
     startLocationUpdates()
   }

--- a/HyprRun/RunViewModel.swift
+++ b/HyprRun/RunViewModel.swift
@@ -100,7 +100,7 @@ class UIRunViewModel: RunViewModel, ObservableObject {
   }
   
   func pauseRun() {
-    timer?.invalidate()
+    //timer?.invalidate()
     self.currentState = .paused
   }
   

--- a/HyprRun/RunViewModel.swift
+++ b/HyprRun/RunViewModel.swift
@@ -100,7 +100,7 @@ class UIRunViewModel: RunViewModel, ObservableObject {
   }
   
   func pauseRun() {
-    //timer?.invalidate()
+    timer?.invalidate()
     self.currentState = .paused
   }
   

--- a/HyprRun/Views/ContentView.swift
+++ b/HyprRun/Views/ContentView.swift
@@ -16,7 +16,8 @@ struct ContentView: View {
   @EnvironmentObject var spotify: Spotify
   @ObservedObject var runViewModel: UIRunViewModel = UIRunViewModel()
   
-  @State private var selectedPlaylists: [String] = []
+  //@State private var selectedPlaylists: [String] = []
+	@State private var selectedPlaylists: [Playlist<PlaylistItemsReference>] = []
   @State private var playlists: [Playlist<PlaylistItemsReference>] = []
   @State private var tracks: [PlaylistItem] = []
   @State private var vibe: Float = 0.0

--- a/HyprRun/Views/HomeView.swift
+++ b/HyprRun/Views/HomeView.swift
@@ -20,7 +20,8 @@ struct HomeView: View {
   @State private var cancellables: Set<AnyCancellable> = []
   
   @Binding var isAuthorized: Bool
-  @Binding var selectedPlaylists: [String]
+  //@Binding var selectedPlaylists: [String]
+	@Binding var selectedPlaylists: [Playlist<PlaylistItemsReference>]
   @Binding var playlists: [Playlist<PlaylistItemsReference>]
   @Binding var tracks: [PlaylistItem]
   @Binding var vibe: Float

--- a/HyprRun/Views/Playlist Views/PlaylistCellView.swift
+++ b/HyprRun/Views/Playlist Views/PlaylistCellView.swift
@@ -28,10 +28,11 @@ struct PlaylistCellView: View {
   @State private var selected = false
 	
   //Binding for selected playlists
-  @Binding var selectedPlaylists: [String]
+  //@Binding var selectedPlaylists: [String]
+	@Binding var selectedPlaylists: [Playlist<PlaylistItemsReference>]
 
 		
-	init(spotify: Spotify, playlist: Playlist<PlaylistItemsReference>, selectedPlaylists: Binding<[String]>) {
+	init(spotify: Spotify, playlist: Playlist<PlaylistItemsReference>, selectedPlaylists: Binding<[Playlist<PlaylistItemsReference>]>) {
     self.spotify = spotify
     self.playlist = playlist
     self._selectedPlaylists = selectedPlaylists
@@ -50,7 +51,7 @@ struct PlaylistCellView: View {
           .padding(.trailing, 5)
         Text("\(playlist.name) - \(playlistDeduplicator.totalItems) items")
         Spacer()
-        SelectBoxView(selected: $selected, selectedPlaylists: $selectedPlaylists, name: playlist.name)
+        SelectBoxView(selected: $selected, selectedPlaylists: $selectedPlaylists, name: [playlist])
 						
 //						if playlistDeduplicator.isDeduplicating {
 //							ProgressView()

--- a/HyprRun/Views/Playlist Views/PlaylistListView.swift
+++ b/HyprRun/Views/Playlist Views/PlaylistListView.swift
@@ -14,7 +14,8 @@ struct PlaylistListView: View {
 		
   @EnvironmentObject var spotify: Spotify
 
-  @Binding var selectedPlaylists: [String]
+  //@Binding var selectedPlaylists: [String]
+	@Binding var selectedPlaylists: [Playlist<PlaylistItemsReference>]
   @Binding var playlists: [Playlist<PlaylistItemsReference>]
   @Binding var tracks: [PlaylistItem]
 		
@@ -25,7 +26,7 @@ struct PlaylistListView: View {
   @State private var couldntLoadPlaylists = false
   
   
-	init(selectedPlaylists: Binding<[String]>, playlists: Binding<[Playlist<PlaylistItemsReference>]>,
+	init(selectedPlaylists: Binding<[Playlist<PlaylistItemsReference>]>, playlists: Binding<[Playlist<PlaylistItemsReference>]>,
 			 tracks: Binding<[PlaylistItem]>) {
     self._selectedPlaylists = selectedPlaylists
     self._playlists = playlists

--- a/HyprRun/Views/PlaylistPreviewView.swift
+++ b/HyprRun/Views/PlaylistPreviewView.swift
@@ -6,13 +6,25 @@
 //
 
 import SwiftUI
+import Combine
 import SpotifyWebAPI
 
 struct PlaylistPreviewView: View {
+	
+	@EnvironmentObject var spotify: Spotify
+	
+	@State private var isLoadingPlaylists = false
+	@State private var couldntLoadPlaylists = false
+	
+	@State private var alert: AlertItem? = nil
+	@State private var cancellables: Set<AnyCancellable> = []
+
 
 	@Binding var selectedPlaylists: [String]
 	@Binding var playlists: [Playlist<PlaylistItemsReference>]
 	@Binding var tracks: [PlaylistItem]
+	
+	
 
 		
 		var body: some View {
@@ -22,6 +34,66 @@ struct PlaylistPreviewView: View {
 						)
 				}
 				.listStyle(PlainListStyle())
+				.onAppear(perform: retrievePlaylists)
 		}
+	
+	func retrievePlaylists() {
+		self.isLoadingPlaylists = true
+		self.playlists = []
+		spotify.api.currentUserPlaylists(limit: 50)
+			// Gets all pages of playlists.
+			.extendPages(spotify.api)
+			.receive(on: RunLoop.main)
+			.sink(receiveCompletion: { completion in
+				self.isLoadingPlaylists = false
+				switch completion {
+				case .finished:
+					self.couldntLoadPlaylists = false
+				case .failure(let error):
+					self.couldntLoadPlaylists = true
+					self.alert = AlertItem(
+						title: "Couldn't Retrieve Playlists",
+						message: error.localizedDescription
+					)
+				}
+			},
+				// We will receive a value for each page of playlists. You could
+				// use Combine's `collect()` operator to wait until all of the
+				// pages have been retrieved.
+				receiveValue: { playlistsPage in
+						let playlists = playlistsPage.items
+						self.playlists.append(contentsOf: playlists)
+				}
+			)
+			.store(in: &cancellables)
+	}
+	
+	func retrieveTracks() {
+		//retrievePlaylists()
+		self.tracks = []
+		print("\(playlists.count)")
+		for playlist in playlists {
+			let pURI = playlist.uri
+			spotify.api.playlist(pURI, market: "US")
+				.sink(receiveCompletion: { completion in
+					print("completion:", completion, terminator: "\n\n\n")
+				}, receiveValue: { playlist in
+						print("\nReceived Playlist")
+						print("------------------------")
+						print("name:", playlist.name)
+						print("link:", playlist.externalURLs?["spotify"] ?? "nil")
+						print("description:", playlist.description ?? "nil")
+						print("total tracks:", playlist.items.total)
+						
+						for track in playlist.items.items.compactMap(\.item) {
+							self.tracks.append(track)
+						}
+						}
+				)
+				.store(in: &cancellables)
+		}
+	}
 }
+
+
 

--- a/HyprRun/Views/PlaylistPreviewView.swift
+++ b/HyprRun/Views/PlaylistPreviewView.swift
@@ -20,12 +20,10 @@ struct PlaylistPreviewView: View {
 	@State private var cancellables: Set<AnyCancellable> = []
 
 
-	@Binding var selectedPlaylists: [String]
+	//@Binding var selectedPlaylists: [String]
+	@Binding var selectedPlaylists: [Playlist<PlaylistItemsReference>]
 	@Binding var playlists: [Playlist<PlaylistItemsReference>]
 	@Binding var tracks: [PlaylistItem]
-	
-	
-
 		
 		var body: some View {
 				List {
@@ -72,7 +70,8 @@ struct PlaylistPreviewView: View {
 		//retrievePlaylists()
 		self.tracks = []
 		print("\(playlists.count)")
-		for playlist in playlists {
+		//for playlist in playlists {
+		for playlist in selectedPlaylists{
 			let pURI = playlist.uri
 			spotify.api.playlist(pURI, market: "US")
 				.sink(receiveCompletion: { completion in

--- a/HyprRun/Views/PlaylistPreviewView.swift
+++ b/HyprRun/Views/PlaylistPreviewView.swift
@@ -66,32 +66,32 @@ struct PlaylistPreviewView: View {
 			.store(in: &cancellables)
 	}
 	
-	func retrieveTracks() {
-		//retrievePlaylists()
-		self.tracks = []
-		print("\(playlists.count)")
-		//for playlist in playlists {
-		for playlist in selectedPlaylists{
-			let pURI = playlist.uri
-			spotify.api.playlist(pURI, market: "US")
-				.sink(receiveCompletion: { completion in
-					print("completion:", completion, terminator: "\n\n\n")
-				}, receiveValue: { playlist in
-						print("\nReceived Playlist")
-						print("------------------------")
-						print("name:", playlist.name)
-						print("link:", playlist.externalURLs?["spotify"] ?? "nil")
-						print("description:", playlist.description ?? "nil")
-						print("total tracks:", playlist.items.total)
-						
-						for track in playlist.items.items.compactMap(\.item) {
-							self.tracks.append(track)
-						}
-						}
-				)
-				.store(in: &cancellables)
-		}
-	}
+//	func retrieveTracks() {
+//		//retrievePlaylists()
+//		self.tracks = []
+//		print("\(playlists.count)")
+//		//for playlist in playlists {
+//		for playlist in selectedPlaylists{
+//			let pURI = playlist.uri
+//			spotify.api.playlist(pURI, market: "US")
+//				.sink(receiveCompletion: { completion in
+//					print("completion:", completion, terminator: "\n\n\n")
+//				}, receiveValue: { playlist in
+//						print("\nReceived Playlist")
+//						print("------------------------")
+//						print("name:", playlist.name)
+//						print("link:", playlist.externalURLs?["spotify"] ?? "nil")
+//						print("description:", playlist.description ?? "nil")
+//						print("total tracks:", playlist.items.total)
+//
+//						for track in playlist.items.items.compactMap(\.item) {
+//							self.tracks.append(track)
+//						}
+//						}
+//				)
+//				.store(in: &cancellables)
+//		}
+//	}
 }
 
 

--- a/HyprRun/Views/RunView.swift
+++ b/HyprRun/Views/RunView.swift
@@ -194,6 +194,7 @@ struct RunView: View {
     playTrack()
 		updateValues()
     self.songDuration = 0
+		self.counter = 0
   }
   
   func nextSong() {
@@ -202,6 +203,7 @@ struct RunView: View {
     playTrack()
 		updateValues()
     self.songDuration = 0
+		self.counter = 0
   }
   
   func playButton() {

--- a/HyprRun/Views/RunView.swift
+++ b/HyprRun/Views/RunView.swift
@@ -61,7 +61,7 @@ struct RunView: View {
 //					let info = getTrack(uri: trackZero.element.uri ?? "NO URI")
 					  Text("\(self.currSongName)").foregroundColor(Color.white)
 						Text("\(self.currArtist)").foregroundColor(Color.white)
-						Text("\(self.counter)").foregroundColor(Color.white)
+						Text("\(elapsedTimeAsString())").foregroundColor(Color.white)
 						AsyncImage(url: self.currImageURL)
 //							.onChange(of: self.currSong) { newValue in
 //								getTrack(uri: trackZero.element.uri ?? "NO URI")
@@ -214,7 +214,7 @@ struct RunView: View {
 
 //extension RunView {
   func elapsedTimeAsString() -> String {
-    let duration = self.songDuration
+    let duration = self.counter
     let minutes = (Int)(duration/60)
     var str_minutes = ""
     

--- a/HyprRun/Views/RunView.swift
+++ b/HyprRun/Views/RunView.swift
@@ -17,8 +17,12 @@ struct RunView: View {
   @ObservedObject var runViewModel: UIRunViewModel
   
   @State var songDuration = 0
+	@State var counter = 0
   @State var isPlaying: Bool = false
   @State var currSong = 0
+	@State var currArtist = ""
+	@State var currURI = ""
+	@State var currSongName = ""
   
   @State var cancellables: Set<AnyCancellable> = []
   @State var pTracks : [PlaylistItem] = []
@@ -26,40 +30,48 @@ struct RunView: View {
   @State private var alert: AlertItem? = nil
   @State private var playTrackCancellable: AnyCancellable? = nil
   
-  let timerSong = Timer.publish(every: 1, on: .main, in: .common)
-//	var timer: Timer?
+	let timerSong = Timer.publish(every: 1, on: .main, in: .default)
 
   
   @Binding var selectedPlaylists: [String]
   @Binding var playlists: [Playlist<PlaylistItemsReference>]
   @Binding var tracks: [PlaylistItem]
-  
+	
+//	init(playlists: Binding<[Playlist<PlaylistItemsReference>]> , selectedPlaylists: Binding<[String]>, tracks: Binding<[PlaylistItem]>, runViewModel: UIRunViewModel) {
+//
+//		_ = timerSong.connect()
+//		self._playlists = playlists
+//		self._tracks = tracks
+//		self._selectedPlaylists = selectedPlaylists
+//		self.runViewModel = runViewModel
+//	}
+	
   var body: some View {
     VStack {
       HStack(spacing: 20) {
         VStack(alignment: .leading) {
-          let trackArray = Array(self.tracks.enumerated())
-          if (trackArray.count > 0) {
-            let trackZero = trackArray[self.currSong]
-            Text("\(trackZero.element.name)").foregroundColor(Color.white)
-						Text("\(trackZero.element.uri ?? "No URI")").foregroundColor(Color.white)
-						
-						//Text("\(id)").foregroundColor(Color.white).onAppear(perform: getTrack(uri: trackZero.element.uri ?? ""))
-//						Text("\(songDuration)")
-//              .foregroundColor(Color.white)
-//							.onReceive(timerSong){ _ in
-//								if self.isPlaying {
-//									songDuration += 1
-//								}
+//          let trackArray = Array(self.tracks.enumerated())
+//          if (trackArray.count > 0) {
+//            let trackZero = trackArray[self.currSong]
+//            Text("\(trackZero.element.name)").foregroundColor(Color.white)
+//					Text("\(trackZero.element.uri ?? "No URI")").foregroundColor(Color.white)
+//					let info = getTrack(uri: trackZero.element.uri ?? "NO URI")
+					  Text("\(self.currSongName)").foregroundColor(Color.white)
+						Text("\(self.currArtist)").foregroundColor(Color.white)
+//							.onChange(of: self.currSong) { newValue in
+//								getTrack(uri: trackZero.element.uri ?? "NO URI")
+//								print("Song changed to \(self.currSong)!")
 //							}
-          }
+//						Text("\(counter)")
+//              .foregroundColor(Color.white)
+//          }
         }
-				.onReceive(timerSong, perform: { input in
-					print("updating")
+//				.onReceive(timerSong, perform: { input in
+//					print("updating")
 //					if self.isPlaying {
-						self.songDuration = self.songDuration + 1
+//						self.songDuration = self.songDuration + 1
 //					}
-				})
+//				})
         .frame(alignment: .center)
         .padding(.bottom, 60)
       }
@@ -224,16 +236,19 @@ struct RunView: View {
       self.currSong -= 1
     }
     playTrack()
+		updateValues()
     self.songDuration = 0
   }
   
   func nextSong() {
     self.currSong += 1
     playTrack()
+		updateValues()
     self.songDuration = 0
   }
   
   func playButton() {
+		updateValues()
     self.isPlaying.toggle()
 		retrievePlaybackState()
 		print(self.isPlaying)
@@ -347,8 +362,22 @@ struct RunView: View {
 		 print("completion: ", completion, terminator: "\n\n\n")
 	 },
 	 receiveValue: { track in
-		 print(track.artists)
+		 if let artists = track.artists {
+			 //print(track.artists?[0].name ?? "NULL")
+			 self.currArtist = track.artists?[0].name ?? "NULL"
+		 }
 	 }
  ).store(in: &cancellables)
+	}
+	
+	func updateValues(){
+		let trackArray = Array(self.tracks.enumerated())
+		if (trackArray.count > 0) {
+			let trackZero = trackArray[self.currSong]
+			self.currSongName = trackZero.element.name
+			self.currURI = trackZero.element.uri ?? "No URI"
+			getTrack(uri: self.currURI)
+//			Text("\(trackZero.element.name)").foregroundColor(Color.white)
+		}
 	}
 }

--- a/HyprRun/Views/RunView.swift
+++ b/HyprRun/Views/RunView.swift
@@ -31,7 +31,8 @@ struct RunView: View {
   @State private var alert: AlertItem? = nil
   @State private var playTrackCancellable: AnyCancellable? = nil
   
-	let timerSong = Timer.publish(every: 1, on: .main, in: .default)
+	let timerSong = Timer.publish(every: 1, on: .current, in: .common).autoconnect()
+	//let timer2 = Timer.publish(every: 1, on: .main, in: .default).autoconnect()
 
   
   //@Binding var selectedPlaylists: [String]
@@ -60,6 +61,7 @@ struct RunView: View {
 //					let info = getTrack(uri: trackZero.element.uri ?? "NO URI")
 					  Text("\(self.currSongName)").foregroundColor(Color.white)
 						Text("\(self.currArtist)").foregroundColor(Color.white)
+						Text("\(self.counter)").foregroundColor(Color.white)
 						AsyncImage(url: self.currImageURL)
 //							.onChange(of: self.currSong) { newValue in
 //								getTrack(uri: trackZero.element.uri ?? "NO URI")
@@ -69,12 +71,12 @@ struct RunView: View {
 //              .foregroundColor(Color.white)
 //          }
         }
-//				.onReceive(timerSong, perform: { input in
-//					print("updating")
-//					if self.isPlaying {
-//						self.songDuration = self.songDuration + 1
-//					}
-//				})
+				.onReceive(self.timerSong) { input in
+					print("updating")
+					if self.isPlaying {
+						self.counter = self.counter + 1
+					}
+				}
         .frame(alignment: .center)
         .padding(.bottom, 60)
       }
@@ -245,6 +247,7 @@ struct RunView: View {
   
   func nextSong() {
     self.currSong += 1
+		self.currSong = self.currSong % self.tracks.count
     playTrack()
 		updateValues()
     self.songDuration = 0
@@ -306,7 +309,8 @@ struct RunView: View {
   
   func playTrack() {
     let trackArray = Array(self.tracks.enumerated())
-    let track = trackArray[self.currSong].element
+		let currSongIndex = self.currSong % trackArray.count
+    let track = trackArray[currSongIndex].element
     let alertTitle = "Couldn't play \(track.name)"
     
     guard let trackURI = track.uri else {

--- a/HyprRun/Views/RunView.swift
+++ b/HyprRun/Views/RunView.swift
@@ -23,6 +23,7 @@ struct RunView: View {
 	@State var currArtist = ""
 	@State var currURI = ""
 	@State var currSongName = ""
+	@State var currImageURL = URL(string: "https://i.scdn.co/image/ab67616d000048517359994525d219f64872d3b1")
   
   @State var cancellables: Set<AnyCancellable> = []
   @State var pTracks : [PlaylistItem] = []
@@ -33,7 +34,8 @@ struct RunView: View {
 	let timerSong = Timer.publish(every: 1, on: .main, in: .default)
 
   
-  @Binding var selectedPlaylists: [String]
+  //@Binding var selectedPlaylists: [String]
+	@Binding var selectedPlaylists: [Playlist<PlaylistItemsReference>]
   @Binding var playlists: [Playlist<PlaylistItemsReference>]
   @Binding var tracks: [PlaylistItem]
 	
@@ -58,6 +60,7 @@ struct RunView: View {
 //					let info = getTrack(uri: trackZero.element.uri ?? "NO URI")
 					  Text("\(self.currSongName)").foregroundColor(Color.white)
 						Text("\(self.currArtist)").foregroundColor(Color.white)
+						AsyncImage(url: self.currImageURL)
 //							.onChange(of: self.currSong) { newValue in
 //								getTrack(uri: trackZero.element.uri ?? "NO URI")
 //								print("Song changed to \(self.currSong)!")
@@ -285,7 +288,7 @@ struct RunView: View {
   
   func retrieveTracks() {
     self.tracks = []
-    for playlist in playlists {
+    for playlist in selectedPlaylists {
       let pURI = playlist.uri
       spotify.api.playlist(pURI, market: "US")
         .sink(
@@ -366,6 +369,11 @@ struct RunView: View {
 			 //print(track.artists?[0].name ?? "NULL")
 			 self.currArtist = track.artists?[0].name ?? "NULL"
 		 }
+		 
+		 if let imageURL = track.album {
+			 self.currImageURL = track.album?.images?[1].url ?? URL(string: "https://i.scdn.co/image/ab67616d000048517359994525d219f64872d3b1")!
+		 }
+	//	 print(track.album?.images?[0].url)
 	 }
  ).store(in: &cancellables)
 	}

--- a/HyprRun/Views/RunView.swift
+++ b/HyprRun/Views/RunView.swift
@@ -23,6 +23,7 @@ struct RunView: View {
 	@State var currArtist = ""
 	@State var currURI = ""
 	@State var currSongName = ""
+	@State var currTrackLength = 0
 	@State var currImageURL = URL(string: "https://i.scdn.co/image/ab67616d000048517359994525d219f64872d3b1")
   
   @State var cancellables: Set<AnyCancellable> = []
@@ -31,8 +32,7 @@ struct RunView: View {
   @State private var alert: AlertItem? = nil
   @State private var playTrackCancellable: AnyCancellable? = nil
   
-	let timerSong = Timer.publish(every: 1, on: .current, in: .common).autoconnect()
-	//let timer2 = Timer.publish(every: 1, on: .main, in: .default).autoconnect()
+	let timerSong = Timer.publish(every: 0.99, on: .main, in: .default).autoconnect()
 
   
   //@Binding var selectedPlaylists: [String]
@@ -71,10 +71,14 @@ struct RunView: View {
 //              .foregroundColor(Color.white)
 //          }
         }
-				.onReceive(self.timerSong) { input in
+				.onReceive(timerSong) { input in
 					print("updating")
 					if self.isPlaying {
 						self.counter = self.counter + 1
+						if(self.counter >= self.currTrackLength){
+							self.counter = 0
+							nextSong()
+						}
 					}
 				}
         .frame(alignment: .center)
@@ -85,11 +89,6 @@ struct RunView: View {
       
       progressView()
       
-//      if self.runViewModel.secondsLeft >= 1 {
-//        countdownView()
-//      } else {
-//        progressView()
-//      }
       controlsBar
     }.frame(maxWidth: .infinity)
   }
@@ -370,14 +369,15 @@ struct RunView: View {
 	 },
 	 receiveValue: { track in
 		 if let artists = track.artists {
-			 //print(track.artists?[0].name ?? "NULL")
 			 self.currArtist = track.artists?[0].name ?? "NULL"
 		 }
+		 
+		 self.currTrackLength = track.durationMS ?? 0
+		 self.currTrackLength /= 1000
 		 
 		 if let imageURL = track.album {
 			 self.currImageURL = track.album?.images?[1].url ?? URL(string: "https://i.scdn.co/image/ab67616d000048517359994525d219f64872d3b1")!
 		 }
-	//	 print(track.album?.images?[0].url)
 	 }
  ).store(in: &cancellables)
 	}

--- a/HyprRun/Views/RunView.swift
+++ b/HyprRun/Views/RunView.swift
@@ -50,7 +50,6 @@ struct RunView: View {
 						AsyncImage(url: self.currImageURL)
         }
 				.onReceive(timerSong) { input in
-					print("updating")
 					if self.isPlaying {
 						self.counter = self.counter + 1
 						if(self.counter >= self.currTrackLength){

--- a/HyprRun/Views/RunView.swift
+++ b/HyprRun/Views/RunView.swift
@@ -40,36 +40,14 @@ struct RunView: View {
   @Binding var playlists: [Playlist<PlaylistItemsReference>]
   @Binding var tracks: [PlaylistItem]
 	
-//	init(playlists: Binding<[Playlist<PlaylistItemsReference>]> , selectedPlaylists: Binding<[String]>, tracks: Binding<[PlaylistItem]>, runViewModel: UIRunViewModel) {
-//
-//		_ = timerSong.connect()
-//		self._playlists = playlists
-//		self._tracks = tracks
-//		self._selectedPlaylists = selectedPlaylists
-//		self.runViewModel = runViewModel
-//	}
-	
   var body: some View {
     VStack {
       HStack(spacing: 20) {
         VStack(alignment: .leading) {
-//          let trackArray = Array(self.tracks.enumerated())
-//          if (trackArray.count > 0) {
-//            let trackZero = trackArray[self.currSong]
-//            Text("\(trackZero.element.name)").foregroundColor(Color.white)
-//					Text("\(trackZero.element.uri ?? "No URI")").foregroundColor(Color.white)
-//					let info = getTrack(uri: trackZero.element.uri ?? "NO URI")
 					  Text("\(self.currSongName)").foregroundColor(Color.white)
 						Text("\(self.currArtist)").foregroundColor(Color.white)
 						Text("\(elapsedTimeAsString())").foregroundColor(Color.white)
 						AsyncImage(url: self.currImageURL)
-//							.onChange(of: self.currSong) { newValue in
-//								getTrack(uri: trackZero.element.uri ?? "NO URI")
-//								print("Song changed to \(self.currSong)!")
-//							}
-//						Text("\(counter)")
-//              .foregroundColor(Color.white)
-//          }
         }
 				.onReceive(timerSong) { input in
 					print("updating")
@@ -183,31 +161,6 @@ struct RunView: View {
         .cornerRadius(20)
         .shadow(radius: 5)
     })
- // }
-  
-  //  func countdownView() -> some View {
-  //    return VStack{
-  //      if self.runViewModel.secondsLeft == 4 {
-  //        Text("Ready?")
-  //          .font(.custom("Avenir-Black", fixedSize: 80))
-  //          .foregroundColor(Color(red: 0, green: 0, blue: 290))
-  //          .frame(maxWidth: .infinity)
-  //          .padding(.top, 175)
-  //          .onReceive(timer) { input in
-  //            self.runViewModel.secondsLeft = self.runViewModel.secondsLeft - 1
-  //          }
-  //      } else {
-  //        Text("\(self.runViewModel.secondsLeft)")
-  //          .font(.custom("Avenir-Black", fixedSize: 90))
-  //          .foregroundColor(Color(red: 0, green: 0, blue: 290))
-  //          .frame(maxWidth: .infinity)
-  //          .padding(.top, 175)
-  //          .onReceive(timer) { input in
-  //            self.runViewModel.secondsLeft = self.runViewModel.secondsLeft - 1
-  //          }
-  //      }
-  //    }
-  //  }
 }
 
 
@@ -389,7 +342,6 @@ struct RunView: View {
 			self.currSongName = trackZero.element.name
 			self.currURI = trackZero.element.uri ?? "No URI"
 			getTrack(uri: self.currURI)
-//			Text("\(trackZero.element.name)").foregroundColor(Color.white)
 		}
 	}
 }

--- a/HyprRun/Views/SelectBoxView.swift
+++ b/HyprRun/Views/SelectBoxView.swift
@@ -6,17 +6,21 @@
 //
 
 import SwiftUI
+import SpotifyWebAPI
 
 struct SelectBoxView: View {
   @Binding var selected: Bool
-  @Binding var selectedPlaylists: [String]
+  //@Binding var selectedPlaylists: [String]
+	@Binding var selectedPlaylists: [Playlist<PlaylistItemsReference>]
 
-  @State var name: String
+  //@State var name: String
+	@State var playlist: [Playlist<PlaylistItemsReference>] 
 	
-	init(selected: Binding<Bool> , selectedPlaylists: Binding<[String]>, name: String) {
+	init(selected: Binding<Bool> , selectedPlaylists: Binding<[Playlist<PlaylistItemsReference>]>, name: [Playlist<PlaylistItemsReference>]) {
 		self._selected = selected
 		self._selectedPlaylists = selectedPlaylists
-		self.name = name
+		self.playlist = name
+		//self.name = name
 	}
 
 	
@@ -26,11 +30,20 @@ struct SelectBoxView: View {
       .onTapGesture {
         self.selected.toggle()
         if(self.selected){
-          self.selectedPlaylists.append(self.name)
+				//	if self.playlist != nil{
+			//		self.selectedPlaylists.append(self.playlist ?? [])
+				//		self.selectedPlaylists = self.selectedPlaylists + self.playlist
+		//			}
+					print("Before \(self.selectedPlaylists.count)")
+					print("Before \(self.playlist.count)")
+					self.selectedPlaylists = Array(self.selectedPlaylists + self.playlist)
+					print("After \(self.selectedPlaylists.count)")
+					print("After \(self.playlist.count)")
+
           self.selectedPlaylists = self.selectedPlaylists.removingDuplicates()
         } else {
           self.selectedPlaylists.removeAll { playList in
-            playList == self.name
+            playList == self.playlist[0]
           }
         }
       }


### PR DESCRIPTION
This PR addresses issues with the user's ability to control music. More specifically it:

- [x] Loads user's playlists without having to go to a specific page 
- [x] Retrieves, and displays, the track's artist and cover image
- [x] Playlist selection is now functional
- [x] Automatically goes to the next track when the current track ends
- [x] Loops back around to the first song when the user has listened to all tacks in their selected playlists
- [x] Resets timer when the user skips to a previous or next song